### PR TITLE
fix(firebase): fix defaultApp already initialized

### DIFF
--- a/Rudder-Firebase/Classes/RudderFirebaseIntegration.m
+++ b/Rudder-Firebase/Classes/RudderFirebaseIntegration.m
@@ -17,8 +17,12 @@
         _GOOGLE_RESERVED_KEYWORDS = [[NSArray alloc] initWithObjects:@"age", @"gender", @"interest", nil];
         _RESERVED_PARAM_NAMES = [[NSArray alloc] initWithObjects:@"product_id", @"name", @"category", @"quantity", @"price", @"currency", @"value", @"order_id", @"tax", @"shipping", @"coupon", nil];
         dispatch_sync(dispatch_get_main_queue(), ^{
-            [FIRApp configure];
-            [RSLogger  logDebug:@"Rudder-Firebase is initialized"];
+            if ([FIRApp defaultApp] == nil){
+                [FIRApp configure];
+                [RSLogger  logDebug:@"Rudder-Firebase is initialized"];
+            } else {
+                [RSLogger  logDebug:@"Firebase core already initialized - skipping on Rudder-Firebase"];
+            }
         });
     }
     return self;


### PR DESCRIPTION
this problem ocour when there's another pod/plugin using and initializing the FirebaseCore. Like [capacitor-community/firebase-crashlytics](https://github.com/capacitor-community/firebase-crashlytics).

## Description of the change

> Description here

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Did not find any.

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
