### PR TITLE
[BugFix] Updated Modular headers to standard Headers for builds failing on RN

### DIFF
--- a/Rudder-Firebase.podspec
+++ b/Rudder-Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Rudder-Firebase'
-  s.version          = '2.0.2'
+  s.version          = '2.0.3'
   s.summary          = 'Privacy and Security focused Segment-alternative. Firebase Native SDK integration support.'
 
   s.description      = <<-DESC
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://github.com/rudderlabs/rudder-integration-firebase-ios'
   s.license          = { :type => "Apache", :file => "LICENSE" }
   s.author           = { 'RudderStack' => 'arnab@rudderlabs.com' }
-  s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-firebase-ios.git' , :tag => 'v2.0.2'}
+  s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-firebase-ios.git' , :tag => 'v2.0.3'}
   s.platform         = :ios, "9.0"
   s.requires_arc = true
 

--- a/Rudder-Firebase/Classes/RudderFirebaseIntegration.h
+++ b/Rudder-Firebase/Classes/RudderFirebaseIntegration.h
@@ -8,8 +8,8 @@
 #import <Foundation/Foundation.h>
 #import <Rudder/Rudder.h>
 
-@import FirebaseCore;
-@import FirebaseAnalytics;
+#import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseAnalytics/FirebaseAnalytics.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Rudder-Firebase/Classes/RudderUtils.h
+++ b/Rudder-Firebase/Classes/RudderUtils.h
@@ -8,8 +8,8 @@
 #import <Foundation/Foundation.h>
 #import <Rudder/Rudder.h>
 
-@import FirebaseCore;
-@import FirebaseAnalytics;
+#import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseAnalytics/FirebaseAnalytics.h>
 
 
 


### PR DESCRIPTION
## Description of the change

Updated Modular headers to standard Headers for builds failing on RN

[Notion Link](https://www.notion.so/rudderstacks/Firebase-iOS-Device-Mode-5a93825065e1404f8c40002690c7d357)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

