### PR TITLE
[Improvement] Mapped property order_id to transaction_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Questions? Please join our [Slack channel](https://resources.rudderstack.com/joi
 2. Rudder-Firebase is available through [CocoaPods](https://cocoapods.org). To install it, add the following line to your Podfile and followed by `pod install`:
 
 ```ruby
-pod 'Rudder-Firebase', '>=2.0.5'
+pod 'Rudder-Firebase', '~> 2.0.6'
 ```
 
 3. Download the `GoogleService-Info.plist` from your Firebase console and put it in your project.

--- a/Rudder-Firebase.podspec
+++ b/Rudder-Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Rudder-Firebase'
-  s.version          = '2.0.5'
+  s.version          = '2.0.6'
   s.summary          = 'Privacy and Security focused Segment-alternative. Firebase Native SDK integration support.'
 
   s.description      = <<-DESC

--- a/Rudder-Firebase/Classes/RudderFirebaseIntegration.m
+++ b/Rudder-Firebase/Classes/RudderFirebaseIntegration.m
@@ -151,6 +151,12 @@
     if (![RudderUtils isEmpty:properties[@"tax"]] && [RudderUtils isNumber:properties[@"tax"]]) {
         [params setValue:[NSNumber numberWithDouble:[properties[@"tax"] doubleValue]] forKey:kFIRParameterTax];
     }
+    // order_id is being mapped to FirebaseAnalytics.Param.TRANSACTION_ID.
+    if (![RudderUtils isEmpty:properties[@"order_id"]]) {
+        [params setValue:[NSString stringWithFormat:@"%@", properties[@"order_id"]] forKey:kFIRParameterTransactionID];
+        // As this change is made at version 2.0.6. So to have the backward compatibility, we're inserting order_id properties as well.
+        [params setValue:[NSString stringWithFormat:@"%@", properties[@"order_id"]] forKey:@"order_id"];
+    }
 }
 
 -(void) handleProducts:(NSMutableDictionary *) params properties: (NSDictionary *) properties isProductsArray:(BOOL) isProductsArray{

--- a/Rudder-Firebase/Classes/RudderUtils.m
+++ b/Rudder-Firebase/Classes/RudderUtils.m
@@ -20,7 +20,7 @@ NSArray *EVENT_WITH_PRODUCTS_AT_ROOT;
 + (void)initialize {
     IDENTIFY_RESERVED_KEYWORDS =  [[NSArray alloc] initWithObjects:@"age", @"gender", @"interest", nil];
     
-    TRACK_RESERVED_KEYWORDS = [[NSArray alloc] initWithObjects:@"product_id", @"name", @"category", @"quantity", @"price", @"currency", @"value", @"revenue", @"total", @"tax", @"shipping", @"coupon", @"cart_id", @"payment_method", @"query", @"list_id", @"promotion_id", @"creative", @"affiliation", @"share_via", @"products", kFIRParameterScreenName, nil];
+    TRACK_RESERVED_KEYWORDS = [[NSArray alloc] initWithObjects:@"product_id", @"name", @"category", @"quantity", @"price", @"currency", @"value", @"revenue", @"total", @"tax", @"shipping", @"coupon", @"cart_id", @"payment_method", @"query", @"list_id", @"promotion_id", @"creative", @"affiliation", @"share_via", @"products", @"order_id", kFIRParameterScreenName, nil];
     
     ECOMMERCE_EVENTS_MAPPING = @{
         ECommPaymentInfoEntered : kFIREventAddPaymentInfo,


### PR DESCRIPTION
## Description of the change

> As user requested to provide the support of order_id, we're mapping order_id to transaction_id. Also, to have the backward compatibility we're sending order_id again.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
