### PR TITLE
feat: add SPM support

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -22,14 +22,14 @@ PODS:
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseCore (11.4.2):
-    - FirebaseCoreInternal (< 12.0, >= 11.4.2)
+  - FirebaseCore (11.9.0):
+    - FirebaseCoreInternal (~> 11.9.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreInternal (11.4.2):
+  - FirebaseCoreInternal (11.9.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseInstallations (11.4.0):
-    - FirebaseCore (~> 11.0)
+  - FirebaseInstallations (11.9.0):
+    - FirebaseCore (~> 11.9.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
@@ -90,9 +90,9 @@ PODS:
   - nanopb/encode (3.30910.0)
   - PromisesObjC (2.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.29.1):
+  - Rudder (1.31.0):
     - MetricsReporter (= 2.0.0)
-  - Rudder-Firebase (3.4.0):
+  - Rudder-Firebase (3.5.0):
     - FirebaseAnalytics (~> 11.4.0)
     - Rudder (~> 1.29)
   - RudderKit (1.4.0)
@@ -124,19 +124,19 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FirebaseAnalytics: 3feef9ae8733c567866342a1000691baaa7cad49
-  FirebaseCore: 6b32c57269bd999aab34354c3923d92a6e5f3f84
-  FirebaseCoreInternal: 35731192cab10797b88411be84940d2beb33a238
-  FirebaseInstallations: 6ef4a1c7eb2a61ee1f74727d7f6ce2e72acf1414
+  FirebaseCore: 7cfcf7e8b33985c06478fd2b96e2f7101eb61a1c
+  FirebaseCoreInternal: 154779013b85b4b290fdba38414df475f42e3096
+  FirebaseInstallations: c76d4931a485fc0cc2dc1d62d3ed0369846ea4b8
   GoogleAppMeasurement: 987769c4ca6b968f2479fbcc9fe3ce34af454b8e
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 731095848aee39d27ff5d0e78233aa5ad8febb0b
-  Rudder-Firebase: 2fc291ed7f97f8853561ac505725d9d660c9f96f
+  Rudder: 04713668b0b7d46f214e6b7b46b60134849661aa
+  Rudder-Firebase: 8f47fae73f71cb000d01fe557f523bd0a03fb178
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: c75d0a8fb8426b261d5f1319351cbc20d7692a7f
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,160 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "abseil",
+        "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+          "version": "1.2024011602.0"
+        }
+      },
+      {
+        "package": "AppCheck",
+        "repositoryURL": "https://github.com/google/app-check.git",
+        "state": {
+          "branch": null,
+          "revision": "61b85103a1aeed8218f17c794687781505fbbef5",
+          "version": "11.2.0"
+        }
+      },
+      {
+        "package": "RSCrashReporter",
+        "repositoryURL": "https://github.com/rudderlabs/crash-reporter-ios",
+        "state": {
+          "branch": null,
+          "revision": "ee563535b64d9d5feacd0fa243663b2658033a19",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "Firebase",
+        "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
+        "state": {
+          "branch": null,
+          "revision": "8328630971a8fdd8072b36bb22bef732eb15e1f0",
+          "version": "11.4.0"
+        }
+      },
+      {
+        "package": "GoogleAppMeasurement",
+        "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
+        "state": {
+          "branch": null,
+          "revision": "4f234bcbdae841d7015258fbbf8e7743a39b8200",
+          "version": "11.4.0"
+        }
+      },
+      {
+        "package": "GoogleDataTransport",
+        "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
+        "state": {
+          "branch": null,
+          "revision": "617af071af9aa1d6a091d59a202910ac482128f9",
+          "version": "10.1.0"
+        }
+      },
+      {
+        "package": "GoogleUtilities",
+        "repositoryURL": "https://github.com/google/GoogleUtilities.git",
+        "state": {
+          "branch": null,
+          "revision": "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "package": "gRPC",
+        "repositoryURL": "https://github.com/google/grpc-binary.git",
+        "state": {
+          "branch": null,
+          "revision": "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+          "version": "1.65.1"
+        }
+      },
+      {
+        "package": "GTMSessionFetcher",
+        "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
+        "state": {
+          "branch": null,
+          "revision": "4d70340d55d7d07cc2fdf8e8125c4c126c1d5f35",
+          "version": "4.4.0"
+        }
+      },
+      {
+        "package": "InteropForGoogle",
+        "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
+        "state": {
+          "branch": null,
+          "revision": "2d12673670417654f08f5f90fdd62926dc3a2648",
+          "version": "100.0.0"
+        }
+      },
+      {
+        "package": "leveldb",
+        "repositoryURL": "https://github.com/firebase/leveldb.git",
+        "state": {
+          "branch": null,
+          "revision": "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+          "version": "1.22.5"
+        }
+      },
+      {
+        "package": "MetricsReporter",
+        "repositoryURL": "https://github.com/rudderlabs/metrics-reporter-ios",
+        "state": {
+          "branch": null,
+          "revision": "e307fa37c6c2d2cccf787d73b5b4b5bc3f650435",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "nanopb",
+        "repositoryURL": "https://github.com/firebase/nanopb.git",
+        "state": {
+          "branch": null,
+          "revision": "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+          "version": "2.30910.0"
+        }
+      },
+      {
+        "package": "Promises",
+        "repositoryURL": "https://github.com/google/promises.git",
+        "state": {
+          "branch": null,
+          "revision": "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "package": "RudderKit",
+        "repositoryURL": "https://github.com/rudderlabs/rudder-ios-kit",
+        "state": {
+          "branch": null,
+          "revision": "8a557a80cc1b0e0bc948c2b17fe0fd3809bcfd61",
+          "version": "1.4.0"
+        }
+      },
+      {
+        "package": "Rudder",
+        "repositoryURL": "https://github.com/rudderlabs/rudder-sdk-ios",
+        "state": {
+          "branch": null,
+          "revision": "2543f659cfc1b772999f932ded1b210f94faeb0c",
+          "version": "1.31.0"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
+          "version": "1.29.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Rudder-Firebase",
+    platforms: [
+        .iOS("12.0"), .tvOS("13.0")
+    ],
+    products: [
+        .library(
+            name: "Rudder-Firebase",
+            targets: ["Rudder-Firebase"]),
+    ],
+    dependencies: [
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", .exact("11.4.0")),
+        .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "1.0.0"),
+    ],
+
+    targets: [
+        .target(
+            name: "Rudder-Firebase",
+            dependencies: [
+                .product(name: "FirebaseAnalytics", package: "Firebase"),
+                .product(name: "Rudder", package: "Rudder"),
+            ],
+            path: "Rudder-Firebase",
+            sources: ["Classes/"],
+            publicHeadersPath: "Classes/",
+            cSettings: [
+                .headerSearchPath("Classes/")
+            ]
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["Rudder-Firebase"]),
     ],
     dependencies: [
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", .exact("11.4.0")),
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk", .exact("11.4.0")),
         .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "1.0.0"),
     ],
 

--- a/Rudder-Firebase/Classes/RudderFirebaseFactory.h
+++ b/Rudder-Firebase/Classes/RudderFirebaseFactory.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Rudder/RSIntegrationFactory.h>
+#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
+#import <Rudder/Rudder.h>
+#else
+#import "Rudder.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Rudder-Firebase/Classes/RudderFirebaseIntegration.h
+++ b/Rudder-Firebase/Classes/RudderFirebaseIntegration.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
 #import <Rudder/Rudder.h>
+#else
+#import "Rudder.h"
+#endif
 
 #import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseAnalytics/FirebaseAnalytics.h>

--- a/Rudder-Firebase/Classes/RudderUtils.h
+++ b/Rudder-Firebase/Classes/RudderUtils.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
 #import <Rudder/Rudder.h>
+#else
+#import "Rudder.h"
+#endif
 
 #import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseAnalytics/FirebaseAnalytics.h>


### PR DESCRIPTION
# Description

- Added SPM support.
- In Factory classes, we have to change the import from `#import <Rudder/Rudder.h>` to the following code: This is required to address the build failure happening when this package is integrated using SPM. In case, if we don't add this then there will be build failure.
```
#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
#import <Rudder/Rudder.h>
#else
#import "Rudder.h"
#endif
```
- NOTE: I've tested the above changes by integrating it through both CocoaPod way and SPM.
- We already have a similar change in the [AppsFlyer-v1](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/blob/7f7b92b56f1369ff3458d32a01b253320d8340c3/Rudder-Appsflyer/Classes/RudderAppsflyerFactory.h#L9C1-L13C7) repo.