### PR TITLE
ci: update deploy cocoapod action to use XCode version 16.2

### DIFF
--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -10,7 +10,12 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout source branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd #v1
+      with:
+        xcode-version: '16.2'
     
     - name: Install Cocoapods
       run: gem install cocoapods


### PR DESCRIPTION
# Description

This pull request updates the GitHub Actions workflow for deploying CocoaPods by upgrading dependencies and adding a new setup step for Xcode.

### Workflow updates:
* [`.github/workflows/deploy-cocoapods.yml`](diffhunk://#diff-fb5a8348edd48edf3db115956b8e689b661acb6073a2b99dd829a5dab513bb4fL13-R18): Updated `actions/checkout` to version `v4` for improved functionality and compatibility.
* [`.github/workflows/deploy-cocoapods.yml`](diffhunk://#diff-fb5a8348edd48edf3db115956b8e689b661acb6073a2b99dd829a5dab513bb4fL13-R18): Added a new step to set up Xcode using `maxim-lobanov/setup-xcode` action, specifying Xcode version `16.2`.
