### PR TITLE
feat: allow standard properties in non-eCommerce events

### DIFF
--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -13,11 +13,6 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v4
         
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd #v1
-        with:
-          xcode-version: '16.2'
-        
       - name: Install Cocoapods
         run: gem install cocoapods
       

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -98,7 +98,7 @@ PODS:
   - RSCrashReporter (1.0.1)
   - Rudder (1.31.1):
     - MetricsReporter (= 2.0.0)
-  - Rudder-Firebase (3.6.0):
+  - Rudder-Firebase (3.7.0):
     - FirebaseAnalytics (~> 11.15.0)
     - Rudder (~> 1.29)
   - RudderKit (1.4.0)
@@ -142,7 +142,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 352cb3417238fb84cc083826d9a5a7cc91efaa69
-  Rudder-Firebase: 764bb8bb052dc032d5b61afa1228b96eb71f46c0
+  Rudder-Firebase: e0943244b3de198102ff082b14c970732ac0e0ba
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: c75d0a8fb8426b261d5f1319351cbc20d7692a7f

--- a/Example/Rudder-Firebase/_ViewController.m
+++ b/Example/Rudder-Firebase/_ViewController.m
@@ -220,6 +220,9 @@ RSClient *client;
     [properties setValue:@"value 1" forKey:@"key1"];
     [properties setValue:@(100) forKey:@"key2"];
     [properties setValue:@(200.25) forKey:@"key3"];
+    // Standard properties
+    [properties setValue:@"INR" forKey:@"currency"];
+    [properties setValue:@(24.55) forKey:@"value"];
     
     return properties;
 }

--- a/Rudder-Firebase/Classes/RudderFirebaseIntegration.m
+++ b/Rudder-Firebase/Classes/RudderFirebaseIntegration.m
@@ -61,7 +61,7 @@
             }
             NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
             [params setValue:screenName forKey:kFIRParameterScreenName];
-            [self attachAllCustomProperties:params properties:message.properties];
+            [self attachAllCustomProperties:params properties:message.properties isECommerceEvent:NO];
             [FIRAnalytics logEventWithName:kFIREventScreenView parameters:params];
         } else if ([type isEqualToString:@"track"]) {
             NSString *eventName = message.event;
@@ -87,7 +87,7 @@
 -(void) handleApplicationOpenedEvent: (NSDictionary *) properties  {
     NSString *firebaseEvent = kFIREventAppOpen;
     NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
-    [self makeFirebaseEvent: firebaseEvent params:params properties:properties];
+    [self makeFirebaseEvent: firebaseEvent params:params properties:properties isECommerceEvent:NO];
 }
 
 -(void) handleECommerceEvent: (NSString *) eventName properties: (NSDictionary *) properties {
@@ -115,7 +115,7 @@
         [self addConstantParamsForECommerceEvent:params eventName:eventName];
         [self handleECommerceEventProperties:params properties:properties firebaseEvent:firebaseEvent];
     }
-    [self makeFirebaseEvent:firebaseEvent params:params properties:properties];
+    [self makeFirebaseEvent:firebaseEvent params:params properties:properties isECommerceEvent:YES];
 }
 
 -(void) addConstantParamsForECommerceEvent:(NSMutableDictionary *) params eventName:(NSString *) eventName {
@@ -129,11 +129,11 @@
 -(void) handleCustomEvent: (NSString *) eventName properties: (NSDictionary *) properties {
     NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
     NSString *firebaseEvent = [RudderUtils getTrimKey:eventName];
-    [self makeFirebaseEvent:firebaseEvent params:params properties:properties];
+    [self makeFirebaseEvent:firebaseEvent params:params properties:properties isECommerceEvent:NO];
 }
 
--(void) makeFirebaseEvent:(NSString *) firebaseEvent params:(NSMutableDictionary *) params properties: (NSDictionary *) properties {
-    [self attachAllCustomProperties:params properties:properties];
+-(void) makeFirebaseEvent:(NSString *) firebaseEvent params:(NSMutableDictionary *) params properties: (NSDictionary *) properties isECommerceEvent:(BOOL) isECommerceEvent{
+    [self attachAllCustomProperties:params properties:properties isECommerceEvent:isECommerceEvent];
     [RSLogger logDebug:[NSString stringWithFormat:@"Logged \"%@\" to Firebase with properties: %@", firebaseEvent, properties]];
     [FIRAnalytics logEventWithName:firebaseEvent parameters:params];
 }
@@ -225,14 +225,17 @@
     }
 }
 
-- (void) attachAllCustomProperties: (NSMutableDictionary *) params properties: (NSDictionary *) properties {
+- (void) attachAllCustomProperties: (NSMutableDictionary *) params properties: (NSDictionary *) properties isECommerceEvent:(BOOL) isECommerceEvent {
     if([RudderUtils isEmpty:properties] || params == nil) {
         return;
     }
     for (NSString *key in [properties keyEnumerator]) {
         NSString* firebaseKey = [RudderUtils getTrimKey:key];
         id value = properties[key];
-        if ([FIREBASE_TRACK_RESERVED_KEYWORDS containsObject:firebaseKey] || [RudderUtils isEmpty:value]) {
+        if (
+            (isECommerceEvent && [FIREBASE_TRACK_RESERVED_KEYWORDS containsObject:firebaseKey])
+            || [RudderUtils isEmpty:value]
+        ) {
             continue;
         }
         if ([value isKindOfClass:[NSNumber class]]) {

--- a/Rudder-Firebase/Classes/RudderFirebaseIntegration.m
+++ b/Rudder-Firebase/Classes/RudderFirebaseIntegration.m
@@ -232,10 +232,8 @@
     for (NSString *key in [properties keyEnumerator]) {
         NSString* firebaseKey = [RudderUtils getTrimKey:key];
         id value = properties[key];
-        if (
-            (isECommerceEvent && [FIREBASE_TRACK_RESERVED_KEYWORDS containsObject:firebaseKey])
-            || [RudderUtils isEmpty:value]
-        ) {
+        if ((isECommerceEvent && [FIREBASE_TRACK_RESERVED_KEYWORDS containsObject:firebaseKey])
+            || [RudderUtils isEmpty:value]) {
             continue;
         }
         if ([value isKindOfClass:[NSNumber class]]) {


### PR DESCRIPTION
# Description

- Allows standard properties (like `product_id`, `name`, `price`, `currency`, `value` etc.) to be sent with non-eCommerce events.
- Also updated the "Build check" GitHub Action.

## Changes
- Custom events, screen events, and Application Opened events now allow all properties

## Before
- All events filtered standard properties ❌
- Custom events couldn't include standard properties like `currency`

## After
- Only eCommerce events filter standard properties ✅
- Custom events can include any properties including standard ones ✅