### PR TITLE
fix: handle lowercase strings and hyphen characters correctly

### DIFF
--- a/Rudder-Firebase/Classes/RudderUtils.m
+++ b/Rudder-Firebase/Classes/RudderUtils.m
@@ -85,7 +85,7 @@ NSArray *EVENT_WITH_PRODUCTS_AT_ROOT;
 }
 
 +(NSString *) getTrimKey:(NSString *) key {
-    NSString *event = [[key stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+    NSString *event = [[[key lowercaseString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] stringByReplacingOccurrencesOfString:@" " withString:@"_"];
     event = [event stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
     NSUInteger trimLength = [@40 unsignedIntegerValue];
     if([event length] > trimLength) {

--- a/Rudder-Firebase/Classes/RudderUtils.m
+++ b/Rudder-Firebase/Classes/RudderUtils.m
@@ -40,7 +40,7 @@ NSArray *EVENT_WITH_PRODUCTS_AT_ROOT;
         ECommPromotionClicked : kFIREventSelectPromotion,
         ECommCartViewed : kFIREventViewCart
     };
-
+    
     PRODUCT_PROPERTIES_MAPPING = @{
         @"product_id" : kFIRParameterItemID,
         @"name" : kFIRParameterItemName,
@@ -48,7 +48,7 @@ NSArray *EVENT_WITH_PRODUCTS_AT_ROOT;
         @"quantity" : kFIRParameterQuantity,
         @"price" : kFIRParameterPrice
     };
-
+    
     EVENT_WITH_PRODUCTS_ARRAY = [[NSArray alloc] initWithObjects:
                                  kFIREventBeginCheckout,
                                  kFIREventPurchase,

--- a/Rudder-Firebase/Classes/RudderUtils.m
+++ b/Rudder-Firebase/Classes/RudderUtils.m
@@ -85,7 +85,8 @@ NSArray *EVENT_WITH_PRODUCTS_AT_ROOT;
 }
 
 +(NSString *) getTrimKey:(NSString *) key {
-    NSString * event = [[[key lowercaseString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+    NSString *event = [[key stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+    event = [event stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
     NSUInteger trimLength = [@40 unsignedIntegerValue];
     if([event length] > trimLength) {
         event = [event substringToIndex:trimLength];


### PR DESCRIPTION
# Description

Fixes event key handling in Firebase iOS integration:

  - Handles hyphen characters - Added replacement of - with _ to ensure Firebase compatibility

  Changes

  File: Rudder-Firebase/Classes/RudderUtils.m

  The getTrimKey: method was modified to:
  1. Replace hyphen characters (-) with underscores (_) in addition to spaces

  Test Plan

  - Verify event names containing hyphens are converted to underscores
  - Verify spaces are still converted to underscores
  - Verify trimming and 40-character limit still work correctly
