### PR TITLE
feat(deps): update Firebase iOS SDK dependency from 11.x to 12.x

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,6 @@
 use_frameworks!
 
-platform :ios, '12.0'
+platform :ios, '15.0'
 
 target 'Rudder-Firebase_Example' do
   pod 'Rudder-Firebase', :path => '../'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,56 +4,57 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - FirebaseAnalytics (11.15.0):
-    - FirebaseAnalytics/Default (= 11.15.0)
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
+  - FirebaseAnalytics (12.11.0):
+    - FirebaseAnalytics/Default (= 12.11.0)
+    - FirebaseCore (~> 12.11.0)
+    - FirebaseInstallations (~> 12.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAnalytics/Default (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
-    - GoogleAppMeasurement/Default (= 11.15.0)
+  - FirebaseAnalytics/Default (12.11.0):
+    - FirebaseCore (~> 12.11.0)
+    - FirebaseInstallations (~> 12.11.0)
+    - GoogleAppMeasurement/Default (= 12.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - FirebaseCore (11.15.0):
-    - FirebaseCoreInternal (~> 11.15.0)
+  - FirebaseCore (12.11.0):
+    - FirebaseCoreInternal (~> 12.11.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
-  - FirebaseCoreInternal (11.15.0):
+  - FirebaseCoreInternal (12.11.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseInstallations (11.15.0):
-    - FirebaseCore (~> 11.15.0)
+  - FirebaseInstallations (12.11.0):
+    - FirebaseCore (~> 12.11.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - PromisesObjC (~> 2.4)
-  - GoogleAdsOnDeviceConversion (2.1.0):
+  - GoogleAdsOnDeviceConversion (3.4.0):
+    - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/Core (11.15.0):
+  - GoogleAppMeasurement/Core (12.11.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/Default (11.15.0):
-    - GoogleAdsOnDeviceConversion (= 2.1.0)
-    - GoogleAppMeasurement/Core (= 11.15.0)
-    - GoogleAppMeasurement/IdentitySupport (= 11.15.0)
+  - GoogleAppMeasurement/Default (12.11.0):
+    - GoogleAdsOnDeviceConversion (~> 3.4.0)
+    - GoogleAppMeasurement/Core (= 12.11.0)
+    - GoogleAppMeasurement/IdentitySupport (= 12.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/IdentitySupport (11.15.0):
-    - GoogleAppMeasurement/Core (= 11.15.0)
+  - GoogleAppMeasurement/IdentitySupport (12.11.0):
+    - GoogleAppMeasurement/Core (= 12.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
@@ -86,22 +87,16 @@ PODS:
   - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - MetricsReporter (2.0.0):
-    - RSCrashReporter (= 1.0.1)
-    - RudderKit (= 1.4.0)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
   - PromisesObjC (2.4.0)
-  - RSCrashReporter (1.0.1)
-  - Rudder (1.31.1):
-    - MetricsReporter (= 2.0.0)
-  - Rudder-Firebase (3.7.0):
-    - FirebaseAnalytics (~> 11.15.0)
+  - Rudder (1.32.0)
+  - Rudder-Firebase (3.8.1):
+    - FirebaseAnalytics (~> 12.8)
     - Rudder (~> 1.29)
-  - RudderKit (1.4.0)
 
 DEPENDENCIES:
   - FBSnapshotTestCase
@@ -117,12 +112,9 @@ SPEC REPOS:
     - GoogleAdsOnDeviceConversion
     - GoogleAppMeasurement
     - GoogleUtilities
-    - MetricsReporter
     - nanopb
     - PromisesObjC
-    - RSCrashReporter
     - Rudder
-    - RudderKit
 
 EXTERNAL SOURCES:
   Rudder-Firebase:
@@ -130,21 +122,18 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  FirebaseAnalytics: 6433dfd311ba78084fc93bdfc145e8cb75740eae
-  FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
-  FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
-  FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
-  GoogleAdsOnDeviceConversion: 2be6297a4f048459e0ae17fad9bfd2844e10cf64
-  GoogleAppMeasurement: 700dce7541804bec33db590a5c496b663fbe2539
+  FirebaseAnalytics: 2513f181a22ba7d5ba547ce0a65f82352cc8a0c9
+  FirebaseCore: 1b39aa6e67b4b4d5771045abf9c9a57a585ff1e7
+  FirebaseCoreInternal: 26601b1134d192ef73e80c0c0110fb96477db687
+  FirebaseInstallations: 3b65e8f4faed02bad1abf5de40e8286c5b13073d
+  GoogleAdsOnDeviceConversion: 98956ec5399cff7c0886cf757f4c8ca4716a5064
+  GoogleAppMeasurement: 937c97829050e8e83b17724cf873323270b26cb5
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 352cb3417238fb84cc083826d9a5a7cc91efaa69
-  Rudder-Firebase: e0943244b3de198102ff082b14c970732ac0e0ba
-  RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
+  Rudder: fcd39cc69aeb05880a789b6ffdaf4ea93f6448a2
+  Rudder-Firebase: 5cd22ffb830f266dd186886dcf2d331781401299
 
-PODFILE CHECKSUM: c75d0a8fb8426b261d5f1319351cbc20d7692a7f
+PODFILE CHECKSUM: bb9ffe72b3701cf07c5ed016aa960e2bf49eb6e0
 
 COCOAPODS: 1.16.2

--- a/Example/Rudder-Firebase.xcodeproj/project.pbxproj
+++ b/Example/Rudder-Firebase.xcodeproj/project.pbxproj
@@ -337,11 +337,8 @@
 				"${BUILT_PRODUCTS_DIR}/FirebaseCoreInternal/FirebaseCoreInternal.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseInstallations/FirebaseInstallations.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
-				"${BUILT_PRODUCTS_DIR}/MetricsReporter/MetricsReporter.framework",
 				"${BUILT_PRODUCTS_DIR}/PromisesObjC/FBLPromises.framework",
-				"${BUILT_PRODUCTS_DIR}/RSCrashReporter/RSCrashReporter.framework",
 				"${BUILT_PRODUCTS_DIR}/Rudder/Rudder.framework",
-				"${BUILT_PRODUCTS_DIR}/RudderKit/RudderKit.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -350,11 +347,8 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreInternal.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseInstallations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MetricsReporter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RSCrashReporter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Rudder.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RudderKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Rudder-Firebase",
     platforms: [
-        .iOS("12.0"), .tvOS("13.0")
+        .iOS("15.0"), .tvOS("15.0")
     ],
     products: [
         .library(
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["Rudder-Firebase"]),
     ],
     dependencies: [
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk", .exact("11.15.0")),
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk", from: "12.8.0"),
         .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "1.0.0"),
     ],
 

--- a/Rudder-Firebase.podspec
+++ b/Rudder-Firebase.podspec
@@ -3,9 +3,9 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 
-firebase_sdk_version = '~> 11.15.0'
+firebase_sdk_version = '~> 12.8'
 rudder_sdk_version = '~> 1.29'
-deployment_target = '12.0'
+deployment_target = '15.0'
 firebase_analytics = 'FirebaseAnalytics'
 
 Pod::Spec.new do |s|


### PR DESCRIPTION
## Description

Update Firebase iOS SDK dependency from version 11.x to 12.x across all package managers (CocoaPods and Swift Package Manager). This also bumps the minimum deployment target from iOS 12.0 to iOS 15.0 (and tvOS 13.0 to tvOS 15.0) to align with Firebase 12.x requirements.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **Podspec**: Updated `firebase_sdk_version` from `~> 11.15.0` to `~> 12.8` and `deployment_target` from `12.0` to `15.0` in `Rudder-Firebase.podspec`.
- **Package.swift**: Updated Firebase dependency from `.exact("11.15.0")` to `from: "12.8.0"`, and bumped platform targets to iOS 15.0 and tvOS 15.0.
- **Example Podfile**: Updated platform target from iOS 12.0 to iOS 15.0.
- **Example Podfile.lock**: Resolved dependency versions now reflect Firebase 12.11.0 and associated transitive dependency updates (GoogleAppMeasurement 12.11.0, GoogleAdsOnDeviceConversion 3.4.0, etc.).
- **Example Xcode project**: Removed framework references for `MetricsReporter`, `RSCrashReporter`, and `RudderKit` which are no longer transitive dependencies of Rudder 1.32.0.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Run `pod install` in the `Example/` directory and verify it resolves successfully with Firebase 12.x.
2. Build the example project targeting iOS 15.0+ and confirm it compiles without errors.
3. Verify `swift build` succeeds with the updated `Package.swift`.
4. Run any existing integration tests to ensure Firebase event logging still works as expected.

## Breaking Changes
- **Minimum deployment target raised**: iOS 12.0 → iOS 15.0, tvOS 13.0 → tvOS 15.0. Apps targeting older OS versions will no longer be able to use this pod/package.
- **Firebase SDK major version bump**: Consumers must update to Firebase 12.x. Any code relying on Firebase 11.x-specific APIs may need adjustment.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
Firebase 12.x requires a minimum deployment target of iOS 15.0, which necessitated the platform version bump. The Rudder SDK also updated to 1.32.0, which removed its transitive dependencies on `MetricsReporter`, `RSCrashReporter`, and `RudderKit`.
