### PR TITLE
chore: create release branch from feature branch SHA instead of origin/master

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -46,6 +46,7 @@ jobs:
           HUSKY: 0
         run: |
           source_branch_name=${GITHUB_REF##*/}
+          source_sha=$(git rev-parse HEAD)
           release_type=release
           git fetch origin master --depth=1
           git merge origin/master
@@ -63,6 +64,7 @@ jobs:
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
 
+          echo "source_sha=$source_sha" >> $GITHUB_OUTPUT
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
@@ -73,7 +75,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          BASE_SHA=$(git rev-parse origin/master)
+          BASE_SHA=${{ steps.create-release.outputs.source_sha }}
           gh api repos/${{ github.repository }}/git/refs \
             --method POST \
             -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
@@ -88,8 +90,11 @@ jobs:
 
       - name: Merge master into release branch
         run: |
+          git config user.name "GitHub actions"
+          git config user.email noreply@github.com
           git fetch origin master
           git merge origin/master --no-edit
+          git push
 
       - name: Update changelog and bump version (file changes only)
         id: finish-release


### PR DESCRIPTION
## Description

Fix the draft-new-release workflow to create the release branch from the feature branch's SHA instead of `origin/master`. Previously, the workflow used `origin/master` as the base SHA when creating the release branch via the GitHub API, which meant the release branch would not contain the feature branch's changes. This change captures the source branch SHA before merging master, and uses it as the base for the new release branch. It also adds the missing git config and `git push` for the "Merge master into release branch" step.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Capture the source branch SHA (`git rev-parse HEAD`) at the start of the "Calculate release version" step, before `origin/master` is merged in.
- Output `source_sha` as a step output so it can be referenced later.
- In the "Create release branch via GitHub API" step, use `source_sha` instead of `git rev-parse origin/master` as the `BASE_SHA`. This ensures the release branch is created from the feature branch's commit, not from master.
- Add `git config user.name` and `git config user.email` in the "Merge master into release branch" step so that the merge commit can be created.
- Add `git push` after merging master into the release branch so the merge is actually pushed to remote.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Trigger the `Draft new release` workflow manually from a `feature/*` or `fix/*` branch.
2. Verify that the newly created release branch is based on the feature/fix branch's SHA (not master).
3. Verify that the release branch contains both the feature branch changes and master's latest changes after the merge step.
4. Confirm the merge commit is pushed to the remote release branch.

## Breaking Changes
None

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
This fix addresses an issue where the draft release workflow was incorrectly basing the release branch on `origin/master` instead of the triggering feature/fix branch. The merge step was also missing git user configuration and a push, so the master merge was never actually persisted to the remote branch.
