### PR TITLE
chore(ci): remove checkout and merge steps from draft-new-release workflow

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -79,18 +79,6 @@ jobs:
             -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
             -f sha="$BASE_SHA"
 
-      - name: Checkout release branch
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          ref: ${{ steps.create-release.outputs.branch_name }}
-          fetch-depth: 0
-
-      - name: Merge master into release branch
-        run: |
-          git fetch origin master
-          git merge origin/master --no-edit
-
       - name: Update changelog and bump version (file changes only)
         id: finish-release
         env:

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -61,4 +61,4 @@ jobs:
         with:
           branches: 'release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Description
Fix two CI workflow issues introduced by the SEC-58 migration (PAT to GITHUB_TOKEN/App Token):

1. **draft-new-release.yml**: Remove the "Checkout release branch" and "Merge master into release branch" steps that caused the `ryancyq/github-signed-commit` action to skip its internal branch switch and push. This resulted in release PRs missing feature code and computing incorrect versions.

2. **publish-new-release.yml**: Use the GitHub App token (with `contents: write`) instead of `GITHUB_TOKEN` (restricted to `contents: read`) for the release branch deletion step, which was silently failing due to insufficient permissions.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **draft-new-release.yml**: Removed 12 lines — the `actions/checkout` for the release branch and the subsequent `git merge origin/master` step. Without these, the signed-commit action correctly detects that `inputBranch !== currentBranch`, performs its internal `switchBranch` + `pushCurrentBranch`, and pushes the feature code to the release branch before making the signed version-bump commit.
- **publish-new-release.yml**: Changed the `Delete release branch` step's `GITHUB_TOKEN` from `${{ secrets.GITHUB_TOKEN }}` to `${{ steps.generate-token.outputs.token }}`. The job-level `permissions: contents: read` (added by SEC-58) restricted the default token, causing the `koj-co/delete-merged-action` to fail silently (error caught internally by the action's try-catch).

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Draft new release**: Trigger the "Draft new release" workflow on a branch with feature commits. Verify the resulting release PR includes all feature code changes alongside the version bump and changelog update, and that the version is computed correctly.
2. **Publish new release**: Merge a release PR into master. Verify the "Publish new github release" workflow completes and the release branch is actually deleted (not just silently failing).

## Breaking Changes
None

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
- The draft-new-release fix aligns this workflow with the working Lotame integration (`rudderlabs/rudder-integration-lotame-ios`), which does not have the checkout/merge steps.
- The publish-new-release branch deletion was silently failing — confirmed by inspecting logs of a Lotame run ([run 22755902808](https://github.com/rudderlabs/rudder-integration-lotame-ios/actions/runs/22755902808/job/66000325643)) which showed the `deleteRef` API call erroring but the step reporting success due to the action's internal error handling.
- The branch deletion still appeared to work because `delete_branch_on_merge` is enabled at the repo level, masking the workflow step's failure.